### PR TITLE
Add feature of alternative profile image sizes

### DIFF
--- a/CoreTweetSupplement/CoreTweetSupplement.cs
+++ b/CoreTweetSupplement/CoreTweetSupplement.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace CoreTweet
@@ -232,6 +233,64 @@ namespace CoreTweet
         public static IEnumerable<ITextPart> EnumerateTextParts(this DirectMessage dm)
         {
             return EnumerateTextParts(dm.Text, dm.Entities);
+        }
+
+        /// <summary>
+        /// Returns the URI suffix for given profile size image variant. See User Profile Images and Banners.
+        /// </summary>
+        /// <returns>The alternative URI suffix in profile image.</returns>
+        /// <param name="size">Size of the image to obtain ("orig" to obtain the original size).</param>
+        private static string GetAlternativeProfileImageUriSuffix(string size)
+        {
+            if (string.IsNullOrEmpty(size))
+                return "";
+            else if (string.Equals(size, "orig"))
+                return "";
+            else
+                return "_" + size;
+        }
+
+        /// <summary>
+        /// Returns the URI for given profile image URI and alternative size. See User Profile Images and Banners.
+        /// </summary>
+        /// <returns>The alternative profile image URI.</returns>
+        /// <param name="uri">The original URI of <see cref="CoreTweet.User.ProfileImageUrl" /> or <see cref="CoreTweet.User.ProfileImageUrlHttps" />.</param>
+        /// <param name="size">Size of the image to obtain ("orig" to obtain the original size).</param>
+        private static Uri GetAlternativeProfileImageUri(Uri uri, string size)
+        {
+            var uriBuilder = new UriBuilder(uri);
+            var path = uriBuilder.Path;
+            int index = path.LastIndexOf("_normal", StringComparison.Ordinal);
+            if (index < 0)
+                return uri;
+            var pathBuilder = new StringBuilder(path.Length);
+            pathBuilder.Append(path, 0, index);
+            pathBuilder.Append(GetAlternativeProfileImageUriSuffix(size));
+            pathBuilder.Append(path, index + 7, path.Length - (index + 7));
+            uriBuilder.Path = pathBuilder.ToString();
+            return uriBuilder.Uri;
+        }
+
+        /// <summary>
+        /// Gets a HTTP-based URL pointing to the user's avatar image with given size. See User Profile Images and Banners.
+        /// </summary>
+        /// <returns>The profile image URL.</returns>
+        /// <param name="user">A <see cref="CoreTweet.User"/> instance.</param>
+        /// <param name="size">Size of the image to obtain ("orig" to obtain the original size).</param>
+        public static Uri GetProfileImageUrl(this User user, string size = "normal")
+        {
+            return GetAlternativeProfileImageUri(user.ProfileImageUrl, size);
+        }
+
+        /// <summary>
+        /// Gets a HTTPS-based URL pointing to the user's avatar image with given size. See User Profile Images and Banners.
+        /// </summary>
+        /// <returns>The profile image URL.</returns>
+        /// <param name="user">A <see cref="CoreTweet.User"/> instance.</param>
+        /// <param name="size">Size of the image to obtain ("orig" to obtain the original size).</param>
+        public static Uri GetProfileImageUrlHttps(this User user, string size = "normal")
+        {
+            return GetAlternativeProfileImageUri(user.ProfileImageUrlHttps, size);
         }
     }
 

--- a/CoreTweetSupplementTest/CoreTweetSupplementTest.cs
+++ b/CoreTweetSupplementTest/CoreTweetSupplementTest.cs
@@ -330,5 +330,45 @@ namespace CoreTweetSupplementTest
             array[2].Text.Is(" &<てすと>&&amp;");
             array[2].Entity.IsNull();
         }
+
+        [TestMethod]
+        public void TestAlternativeProfileImageUriSuffix()
+        {
+            TestTarget.InvokeStatic("GetAlternativeProfileImageUriSuffix", new Type[] { typeof(string) }, new object[] { null }).Is("");
+            TestTarget.InvokeStatic("GetAlternativeProfileImageUriSuffix", "").Is("");
+            TestTarget.InvokeStatic("GetAlternativeProfileImageUriSuffix", "orig").Is("");
+            TestTarget.InvokeStatic("GetAlternativeProfileImageUriSuffix", "mini").Is("_mini");
+            TestTarget.InvokeStatic("GetAlternativeProfileImageUriSuffix", "normal").Is("_normal");
+            TestTarget.InvokeStatic("GetAlternativeProfileImageUriSuffix", "bigger").Is("_bigger");
+        }
+
+        [TestMethod]
+        public void TestAlternativeProfileImageUri()
+        {
+            // Basic tests
+            TestTarget.InvokeStatic("GetAlternativeProfileImageUri",
+                new Uri("http://example.com/path1/path2/test_normal.png"), "orig")
+                .Is(new Uri("http://example.com/path1/path2/test.png"));
+            TestTarget.InvokeStatic("GetAlternativeProfileImageUri",
+                new Uri("http://example.com/path1/path2/test_normal.gif"), "normal")
+                .Is(new Uri("http://example.com/path1/path2/test_normal.gif"));
+            TestTarget.InvokeStatic("GetAlternativeProfileImageUri",
+                new Uri("http://example.com/path1/path2/test_normal.jpg"), "mini")
+                .Is(new Uri("http://example.com/path1/path2/test_mini.jpg"));
+            TestTarget.InvokeStatic("GetAlternativeProfileImageUri",
+                new Uri("http://example.com/path1/path2/test_normal"), "bigger")
+                .Is(new Uri("http://example.com/path1/path2/test_bigger"));
+            // URL escape tests
+            TestTarget.InvokeStatic("GetAlternativeProfileImageUri",
+                new Uri("http://example.com/%E3%83%86%E3%82%B9%E3%83%88_normal.png"), "orig")
+                .Is(new Uri("http://example.com/%E3%83%86%E3%82%B9%E3%83%88.png"));
+            TestTarget.InvokeStatic("GetAlternativeProfileImageUri",
+                new Uri("http://example.com/%83%65%83%58%83%67_normal.jpeg"), "mini")
+                .Is(new Uri("http://example.com/%83%65%83%58%83%67_mini.jpeg"));
+            // Complex paths
+            TestTarget.InvokeStatic("GetAlternativeProfileImageUri",
+                new Uri("http://example.com//path1//path2/test_normal.gif?test1=test2&test3=%83%65%83%58%83%674&test5=%E3%83%86%E3%82%B9%E3%83%886#example-section"), "bigger")
+                .Is(new Uri("http://example.com//path1//path2/test_bigger.gif?test1=test2&test3=%83%65%83%58%83%674&test5=%E3%83%86%E3%82%B9%E3%83%886#example-section"));
+        }
     }
 }


### PR DESCRIPTION
User.ProfileImageUrl and User.ProfileImageUrlHttps returns "normal" variant of the user's uploaded image and there's no Twitter API to obtain other variants.
According to https://dev.twitter.com/docs/user-profile-images-and-banners, replacing URL string will simply work.
This commit adds two new extension methods GetProfileImageUrl and GetProfileImageUrlHttps which accepts alternative variant size as 'size' parameter (expected values are "normal", "bigger", "mini", "orig" and null-or-empty string [implies "orig"]).

CoreTweetSupplement に追加するとしたらこういう形の pull request で良いのかな?
