### PR TITLE
Update CoreTweet and Newtonsoft.Json

### DIFF
--- a/CoreTweetSupplement.Pcl/CoreTweetSupplement.Pcl.csproj
+++ b/CoreTweetSupplement.Pcl/CoreTweetSupplement.Pcl.csproj
@@ -51,7 +51,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="CoreTweet">
-      <HintPath>..\packages\CoreTweet.0.4.1\lib\portable-net4+wp8+win81+wpa81+MonoAndroid+MonoTouch\CoreTweet.dll</HintPath>
+      <HintPath>..\packages\CoreTweet.0.4.3.110\lib\portable-net4+sl5+wp8+win8+wpa81+MonoAndroid+MonoTouch+Xamarin.iOS\CoreTweet.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\portable-net40+sl4+wp7+win8\Newtonsoft.Json.dll</HintPath>

--- a/CoreTweetSupplement.Pcl/packages.config
+++ b/CoreTweetSupplement.Pcl/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CoreTweet" version="0.4.1" targetFramework="portable-net4+wp8+win81+wpa81+MonoAndroid+MonoTouch" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="portable-net40+sl4+wp7+win8" />
+  <package id="CoreTweet" version="0.4.3.110" targetFramework="portable-net4+wp8+win81+wpa81+MonoAndroid+MonoTouch" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="portable-net40+sl4+wp7+win8" />
 </packages>

--- a/CoreTweetSupplement.Pcl/packages.config
+++ b/CoreTweetSupplement.Pcl/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CoreTweet" version="0.4.3.110" targetFramework="portable-net4+wp8+win81+wpa81+MonoAndroid+MonoTouch" />
+  <package id="CoreTweet" version="0.4.3.110" targetFramework="portable-net4+sl5+wp8+win8+wpa81+MonoAndroid+MonoTouch+Xamarin.iOS" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="portable-net40+sl4+wp7+win8" />
 </packages>

--- a/CoreTweetSupplement/CoreTweetSupplement.csproj
+++ b/CoreTweetSupplement/CoreTweetSupplement.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="CoreTweet">
-      <HintPath>..\packages\CoreTweet.0.4.1\lib\net40\CoreTweet.dll</HintPath>
+      <HintPath>..\packages\CoreTweet.0.4.3.110\lib\net40\CoreTweet.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="Newtonsoft.Json">

--- a/CoreTweetSupplement/packages.config
+++ b/CoreTweetSupplement/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CoreTweet" version="0.4.1" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
+  <package id="CoreTweet" version="0.4.3.110" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
 </packages>

--- a/CoreTweetSupplementTest/CoreTweetSupplementTest.csproj
+++ b/CoreTweetSupplementTest/CoreTweetSupplementTest.csproj
@@ -41,9 +41,9 @@
     </DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CoreTweet, Version=0.4.1.21404, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="CoreTweet, Version=0.4.3.110, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\CoreTweet.0.4.1\lib\net45\CoreTweet.dll</HintPath>
+      <HintPath>..\packages\CoreTweet.0.4.3.110\lib\net45\CoreTweet.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/CoreTweetSupplementTest/packages.config
+++ b/CoreTweetSupplementTest/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ChainingAssertion" version="1.7.1.0" targetFramework="net45" />
-  <package id="CoreTweet" version="0.4.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
+  <package id="CoreTweet" version="0.4.3.110" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
`CoreTweet.Entities#HashTags` の型が `SymbolEntity[]` から `HashtagEntity[]` に変更されたことにより実行時エラーになっていたためアップデート。