### PR TITLE
Update CoreTweet and Newtonsoft.Json

### DIFF
--- a/CoreTweetSupplement.Pcl/CoreTweetSupplement.Pcl.csproj
+++ b/CoreTweetSupplement.Pcl/CoreTweetSupplement.Pcl.csproj
@@ -39,6 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -50,11 +51,13 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="CoreTweet">
-      <HintPath>..\packages\CoreTweet.0.4.3.110\lib\portable-net4+sl5+wp8+win8+wpa81+MonoAndroid+MonoTouch+Xamarin.iOS\CoreTweet.dll</HintPath>
+    <Reference Include="CoreTweet, Version=0.5.3.40350, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CoreTweet.0.5.3\lib\portable-net4+sl5+wp8+win8+wpa81+MonoAndroid+MonoTouch+Xamarin.iOS\CoreTweet.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\portable-net40+sl4+wp7+win8\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />

--- a/CoreTweetSupplement.Pcl/packages.config
+++ b/CoreTweetSupplement.Pcl/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CoreTweet" version="0.4.3.110" targetFramework="portable-net4+sl5+wp8+win8+wpa81+MonoAndroid+MonoTouch+Xamarin.iOS" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="portable-net40+sl4+wp7+win8" />
+  <package id="CoreTweet" version="0.5.3" targetFramework="portable4-net4+sl5+win8+wp8+wpa81" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="portable4-net4+sl5+win8+wp8+wpa81" />
 </packages>

--- a/CoreTweetSupplement/CoreTweetSupplement.cs
+++ b/CoreTweetSupplement/CoreTweetSupplement.cs
@@ -277,13 +277,13 @@ namespace CoreTweet
         /// <returns>The alternative profile image URI.</returns>
         /// <param name="uri">The original URI of <see cref="CoreTweet.User.ProfileImageUrl" /> or <see cref="CoreTweet.User.ProfileImageUrlHttps" />.</param>
         /// <param name="size">Size of the image to obtain ("orig" to obtain the original size).</param>
-        private static Uri GetAlternativeProfileImageUri(Uri uri, string size)
+        private static Uri GetAlternativeProfileImageUri(string uri, string size)
         {
             var uriBuilder = new UriBuilder(uri);
             var path = uriBuilder.Path;
             int index = path.LastIndexOf("_normal", StringComparison.Ordinal);
             if (index < 0)
-                return uri;
+                return uriBuilder.Uri;
             var pathBuilder = new StringBuilder(path.Length);
             pathBuilder.Append(path, 0, index);
             pathBuilder.Append(GetAlternativeProfileImageUriSuffix(size));

--- a/CoreTweetSupplement/CoreTweetSupplement.csproj
+++ b/CoreTweetSupplement/CoreTweetSupplement.csproj
@@ -34,6 +34,7 @@
     <DocumentationFile>bin\Release\CoreTweetSupplement.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -41,13 +42,15 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="CoreTweet">
-      <HintPath>..\packages\CoreTweet.0.4.3.110\lib\net40\CoreTweet.dll</HintPath>
+    <Reference Include="CoreTweet, Version=0.5.3.40351, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CoreTweet.0.5.3\lib\net40\CoreTweet.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\portable-net40+sl4+wp7+win8\Newtonsoft.Json.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/CoreTweetSupplement/packages.config
+++ b/CoreTweetSupplement/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CoreTweet" version="0.4.3.110" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
+  <package id="CoreTweet" version="0.5.3" targetFramework="net4" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net4" />
 </packages>

--- a/CoreTweetSupplementTest/CoreTweetSupplementTest.csproj
+++ b/CoreTweetSupplementTest/CoreTweetSupplementTest.csproj
@@ -41,14 +41,14 @@
     </DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CoreTweet, Version=0.4.3.110, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\CoreTweet.0.4.3.110\lib\net45\CoreTweet.dll</HintPath>
+    <Reference Include="CoreTweet, Version=0.5.3.40351, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CoreTweet.0.5.3\lib\net45\CoreTweet.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>
@@ -70,6 +70,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/CoreTweetSupplementTest/packages.config
+++ b/CoreTweetSupplementTest/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ChainingAssertion" version="1.7.1.0" targetFramework="net45" />
-  <package id="CoreTweet" version="0.4.3.110" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
+  <package id="CoreTweet" version="0.5.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
`CoreTweet.User.ProfileImageUrl` ならびに `CoreTweet.User.ProfileImageUrlHttps` が `Uri` から `String` に変更になったことによる実行時例外のため
